### PR TITLE
libunibreak: new port in devel

### DIFF
--- a/devel/libunibreak/Portfile
+++ b/devel/libunibreak/Portfile
@@ -1,0 +1,29 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; truncate-lines: t; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+# vim: set fileencoding=utf-8 tabstop=8 shiftwidth=4 softtabstop=4 noexpandtab filetype=tcl :
+
+PortSystem	    1.0
+
+name		    libunibreak
+version		    3.0
+revision	    0
+conflicts           liblinebreak
+platforms	    darwin
+categories	    devel
+maintainers	    nomaintainer
+description	    Unicode linebreak library
+long_description								    \
+    libunibreak, an implementation of the line breaking algorithm as described	    \
+    in Unicode 5.2.0 Standard Annex 14, Revision 24, available at		    \
+    http://www.unicode.org/reports/tr14/tr14-24.html
+
+homepage	    http://vimgadgets.sourceforge.net/
+master_sites	    sourceforge:vimgadgets
+use_parallel_build  no
+universal_variant   no
+
+checksums           md5     13e9a325c00b5943d6afb21f028635e6 \
+                    sha1    8a506e4197258caa2c9a7b6cd3cabc5b6672d7c0 \
+                    rmd160  4ac95004e6657a4216bcd991905c5c9eb26defe9 \
+                    sha256  4b88c85a4568a7b88aa748c2aa15c52e0ae8a8c1107ead3ed6846e6121d6ea29 \
+                    size    797361
+

--- a/devel/xapian-core/Portfile
+++ b/devel/xapian-core/Portfile
@@ -33,6 +33,9 @@ if {${subport} eq ${name}} {
                                 sha256  c55c9bc8613ad3ec2c218eafca088c218ab7cddcba7ef08f3af0e542f4e521bc \
                                 size    3250704
 
+    platform darwin 8 {
+        patchfiles-append       tiger-needs-header.diff
+    }
     # TODO: Fix xapian-config to not require the .la file
     # /opt/local/bin/xapian-config --ltlibs --cxxflags
     # /opt/local/bin/xapian-config: Can't find libxapian.la to link against.

--- a/devel/xapian-core/files/tiger-needs-header.diff
+++ b/devel/xapian-core/files/tiger-needs-header.diff
@@ -1,13 +1,10 @@
---- backends/glass/glass_version.h
-+++ backends/glass/glass_version.h
-@@ -22,9 +22,10 @@
-#ifndef XAPIAN_INCLUDED_GLASS_VERSION_H
-#define XAPIAN_INCLUDED_GLASS_VERSION_H
-
-#include "glass_changes.h"
-#include "glass_defs.h"
+--- backends/glass/glass_version.h	2024-12-06 10:12:41
++++ backends/glass/glass_version.h	2025-11-18 17:51:58
+@@ -30,6 +30,7 @@
+ #include <algorithm>
+ #include <cstring>
+ #include <string>
 +#include <sys/types.h>
-
-#include "omassert.h"
-
-#include <algorithm>
+ 
+ #include "backends/uuids.h"
+ #include "internaltypes.h"

--- a/devel/xapian-core/files/tiger-needs-header.diff
+++ b/devel/xapian-core/files/tiger-needs-header.diff
@@ -1,0 +1,12 @@
+--- backends/glass/glass_version.h
++++ backends/glass/glass_version.h
+@@ -34,8 +34,9 @@
+ #include "backends/uuids.h"
+ #include "internaltypes.h"
+ #include "min_non_zero.h"
+ #include "xapian/types.h"
++#include <sys/types.h>
+ 
+ namespace Glass {
+ 
+ class RootInfo {

--- a/devel/xapian-core/files/tiger-needs-header.diff
+++ b/devel/xapian-core/files/tiger-needs-header.diff
@@ -1,12 +1,13 @@
 --- backends/glass/glass_version.h
 +++ backends/glass/glass_version.h
-@@ -34,8 +34,9 @@
- #include "backends/uuids.h"
- #include "internaltypes.h"
- #include "min_non_zero.h"
- #include "xapian/types.h"
+@@ -22,9 +22,10 @@
+#ifndef XAPIAN_INCLUDED_GLASS_VERSION_H
+#define XAPIAN_INCLUDED_GLASS_VERSION_H
+
+#include "glass_changes.h"
+#include "glass_defs.h"
 +#include <sys/types.h>
- 
- namespace Glass {
- 
- class RootInfo {
+
+#include "omassert.h"
+
+#include <algorithm>


### PR DESCRIPTION
This is a newer version of: https://ports.macports.org/port/liblinebreak/details/
My guess is that Macports never updated their version because of the name change.
However, this newer version is useful for compiling newer programs that rely on it that expect the libunibreak name.